### PR TITLE
Support unicode in lexer

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -210,11 +210,13 @@ mod tests {
             10 != 9;
             "foobar"
             "foo bar"
+            foo
+            Bar_123
             [1, 2, 3];
             {"foo": "bar"}
             "日本語"
             "🐒"
-            let 🙈🙉🙊 = 見ざる聞かざる言わざる
+            let 🙈🙉🙊 = "見ざる聞かざる言わざる"
         "#;
 
         let tests = [
@@ -293,6 +295,8 @@ mod tests {
             Token::Semicolon,
             Token::String("foobar".to_string()),
             Token::String("foo bar".to_string()),
+            Token::Ident("foo".to_string()),
+            Token::Ident("Bar_123".to_string()),
             Token::Lbracket,
             Token::Int("1".to_string()),
             Token::Comma,
@@ -311,7 +315,7 @@ mod tests {
             Token::Let,
             Token::Ident("🙈🙉🙊".to_string()),
             Token::Assign,
-            Token::Ident("見ざる聞かざる言わざる".to_string()),
+            Token::String("見ざる聞かざる言わざる".to_string()),
             Token::Eof,
         ];
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -214,6 +214,7 @@ mod tests {
             {"foo": "bar"}
             "日本語"
             "🐒"
+            let 🙈🙉🙊 = 見ざる聞かざる言わざる
         "#;
 
         let tests = [
@@ -307,6 +308,10 @@ mod tests {
             Token::Rbrace,
             Token::String("日本語".to_string()),
             Token::String("🐒".to_string()),
+            Token::Let,
+            Token::Ident("🙈🙉🙊".to_string()),
+            Token::Assign,
+            Token::Ident("見ざる聞かざる言わざる".to_string()),
             Token::Eof,
         ];
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -177,7 +177,8 @@ impl Lexer {
 }
 
 fn is_letter(ch: char) -> bool {
-    'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+    // `is_alphabetic` includes kanji but not emoji.
+    ch.is_alphabetic() || ch == '_'
 }
 
 fn is_digit(ch: char) -> bool {
@@ -221,6 +222,7 @@ mod tests {
             [1, 2, 3];
             {"foo": "bar"}
             "日本語"
+            識別子
             "🐒"
             let 🙈🙉🙊 = "見ざる聞かざる言わざる"
         "#;
@@ -317,6 +319,7 @@ mod tests {
             Token::String("bar".to_string()),
             Token::Rbrace,
             Token::String("日本語".to_string()),
+            Token::Ident("識別子".to_string()),
             Token::String("🐒".to_string()),
             Token::Let,
             Token::Ident("🙈🙉🙊".to_string()),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -212,6 +212,8 @@ mod tests {
             "foo bar"
             [1, 2, 3];
             {"foo": "bar"}
+            "日本語"
+            "🐒"
         "#;
 
         let tests = [
@@ -303,6 +305,8 @@ mod tests {
             Token::Colon,
             Token::String("bar".to_string()),
             Token::Rbrace,
+            Token::String("日本語".to_string()),
+            Token::String("🐒".to_string()),
             Token::Eof,
         ];
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -177,8 +177,15 @@ impl Lexer {
 }
 
 fn is_letter(ch: char) -> bool {
-    // `is_alphabetic` includes kanji but not emoji.
-    ch.is_alphabetic() || ch == '_'
+    ch == '_'
+        || ch == '$'
+        // `is_alphabetic` includes kanji but not emoji.
+        || ch.is_alphabetic()
+        // A rough emoji range
+        // TODO: Review https://unicode.org/Public/emoji/12.0/emoji-data.txt
+        // TODO: What to do with modifiers?
+        || ('\u{203C}' <= ch && ch <= '\u{3299}')
+        || ('\u{1F000}' <= ch && ch <= '\u{1FA95}')
 }
 
 fn is_digit(ch: char) -> bool {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -129,7 +129,12 @@ impl Lexer {
 
     fn read_identifier(&mut self) -> &str {
         let position = self.position;
-        while is_letter(self.ch) {
+        // The first character needs to be a letter.
+        if is_letter(self.ch) {
+            self.read_char();
+        }
+        // The second character and after can be a letter or a digit.
+        while is_letter(self.ch) || is_digit(self.ch) {
             self.read_char();
         }
         &self.input[position..self.position]


### PR DESCRIPTION
Use `Chars` to support UTF-8 in string literals and identifiers.

- [x] String literals
- [x] Identifiers