### PR TITLE
Support float type

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -310,6 +310,7 @@ fn lookup_definition(byte: u8) -> Option<Definition> {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Constant {
     Integer(i64),
+    Float(f64),
     String(String),
     CompiledFunction(CompiledFunction),
 }
@@ -318,6 +319,7 @@ impl Constant {
     pub fn type_name(&self) -> &str {
         match self {
             Constant::Integer(_) => "INTEGER",
+            Constant::Float(_) => "FLOAT",
             Constant::String(_) => "STRING",
             Constant::CompiledFunction(_) => "COMPILED_FUNCTION",
         }
@@ -328,6 +330,7 @@ impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Constant::Integer(value) => write!(f, "{}", value),
+            Constant::Float(value) => write!(f, "{}", value),
             Constant::String(value) => write!(f, "\"{}\"", value),
             Constant::CompiledFunction(cf) => write!(f, "{}", cf),
         }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -87,7 +87,7 @@ fn eval_array_literal(exps: &[Expression], env: Rc<RefCell<Environment>>) -> Eva
 }
 
 fn eval_hash_literal(
-    pairs: &Vec<(Expression, Expression)>,
+    pairs: &[(Expression, Expression)],
     env: Rc<RefCell<Environment>>,
 ) -> EvalResult {
     let mut map = HashMap::new();
@@ -172,6 +172,7 @@ fn eval_prefix_expression(
         Prefix::Bang => Ok(Object::Boolean(!obj.is_truthy())),
         Prefix::Minus => match obj {
             Object::Integer(value) => Ok(Object::Integer(-value)),
+            Object::Float(value) => Ok(Object::Float(-value)),
             _ => Err(EvalError::UnknownPrefixOperator(prefix.clone(), obj)),
         },
     }
@@ -192,6 +193,15 @@ fn eval_infix_expression(
         }
         (Object::Integer(left), Object::Integer(right)) => {
             eval_integer_infix_expression(infix, left, right)
+        }
+        (Object::Integer(left), Object::Float(right)) => {
+            eval_float_infix_expression(infix, left as f64, right)
+        }
+        (Object::Float(left), Object::Integer(right)) => {
+            eval_float_infix_expression(infix, left, right as f64)
+        }
+        (Object::Float(left), Object::Float(right)) => {
+            eval_float_infix_expression(infix, left, right)
         }
         (Object::String(left), Object::String(right)) => {
             eval_string_infix_expression(infix, &left, &right)
@@ -222,6 +232,19 @@ fn eval_integer_infix_expression(infix: &Infix, left: i64, right: i64) -> EvalRe
         Infix::Minus => Object::Integer(left - right),
         Infix::Asterisk => Object::Integer(left * right),
         Infix::Slash => Object::Integer(left / right),
+    })
+}
+
+fn eval_float_infix_expression(infix: &Infix, left: f64, right: f64) -> EvalResult {
+    Ok(match infix {
+        Infix::Eq => Object::Boolean(left == right),
+        Infix::NotEq => Object::Boolean(left != right),
+        Infix::Lt => Object::Boolean(left < right),
+        Infix::Gt => Object::Boolean(left > right),
+        Infix::Plus => Object::Float(left + right),
+        Infix::Minus => Object::Float(left - right),
+        Infix::Asterisk => Object::Float(left * right),
+        Infix::Slash => Object::Float(left / right),
     })
 }
 
@@ -335,6 +358,25 @@ mod evalator_tests {
             ("(5 + 10 * 2 + 15 / 3) * 2 + -10", "50"),
         ]);
     }
+
+    #[test]
+    fn eval_float() {
+        expect_values(vec![
+            // Prefix
+            ("-12.3", "-12.3"),
+            ("-(-12.3)", "12.3"),
+            ("-(2.2 * 3.3)", "-7.26"),
+            // Infix
+            ("2.8 + 3.4", "6.199999999999999"),
+            ("2.0 - 3.1", "-1.1"),
+            ("2.2 * 3.3", "7.26"),
+            ("6.16 / 2.8", "2.2"),
+            ("-50.4 + 100.4 + -50.0", "0.000000000000007105427357601002"),
+        ]);
+    }
+
+    #[test]
+    fn eval_integer_and_float() {}
 
     #[test]
     fn eval_if() {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -235,8 +235,10 @@ fn eval_integer_infix_expression(infix: &Infix, left: i64, right: i64) -> EvalRe
     })
 }
 
+#[allow(clippy::float_cmp)]
 fn eval_float_infix_expression(infix: &Infix, left: f64, right: f64) -> EvalResult {
     Ok(match infix {
+        // Use exact comparison for floats for now.
         Infix::Eq => Object::Boolean(left == right),
         Infix::NotEq => Object::Boolean(left != right),
         Infix::Lt => Object::Boolean(left < right),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BlockStatement, Expression, HashLiteral, Infix, Prefix, Program, Statement};
+use crate::ast::{BlockStatement, Expression, Infix, Prefix, Program, Statement};
 use crate::object::{
     assert_argument_count, builtin, Environment, EvalError, EvalResult, HashKey, Object,
 };
@@ -54,11 +54,12 @@ fn eval_statement(statement: &Statement, env: Rc<RefCell<Environment>>) -> EvalR
 
 fn eval_expression(expression: &Expression, env: Rc<RefCell<Environment>>) -> EvalResult {
     match expression {
-        Expression::IntegerLiteral(int) => Ok(Object::Integer(*int)),
+        Expression::IntegerLiteral(value) => Ok(Object::Integer(*value)),
+        Expression::FloatLiteral(value) => Ok(Object::Float(*value)),
         Expression::StringLiteral(s) => Ok(Object::String(s.to_string())),
         Expression::Boolean(value) => Ok(Object::Boolean(*value)),
         Expression::Array(values) => eval_array_literal(values, env),
-        Expression::Hash(HashLiteral { pairs }) => eval_hash_literal(pairs, env),
+        Expression::Hash(pairs) => eval_hash_literal(pairs, env),
         Expression::Index(left, index) => eval_index_expression(left, index, env),
         Expression::Prefix(prefix, exp) => eval_prefix_expression(prefix, exp.as_ref(), env),
         Expression::Infix(infix, left, right) => {
@@ -86,7 +87,7 @@ fn eval_array_literal(exps: &[Expression], env: Rc<RefCell<Environment>>) -> Eva
 }
 
 fn eval_hash_literal(
-    pairs: &HashMap<Expression, Expression>,
+    pairs: &Vec<(Expression, Expression)>,
     env: Rc<RefCell<Environment>>,
 ) -> EvalResult {
     let mut map = HashMap::new();

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -109,7 +109,14 @@ impl Lexer {
                     let ident = self.read_identifier();
                     return token::lookup_ident(ident);
                 } else if is_digit(self.ch) {
-                    return Token::Int(self.read_number().to_string());
+                    let integer_part = self.read_number().to_string();
+                    if self.ch == '.' && is_digit(self.peek_char()) {
+                        self.read_char();
+                        let fractional_part = self.read_number();
+                        return Token::Float(format!("{}.{}", integer_part, fractional_part));
+                    } else {
+                        return Token::Int(integer_part);
+                    }
                 } else {
                     tok = Token::Illegal
                 }
@@ -220,6 +227,9 @@ mod tests {
                 return false;
             }
 
+            0
+            12.345
+            0.12
             10 == 10;
             10 != 9;
             "foobar"
@@ -300,6 +310,9 @@ mod tests {
             Token::False,
             Token::Semicolon,
             Token::Rbrace,
+            Token::Int("0".to_string()),
+            Token::Float("12.345".to_string()),
+            Token::Float("0.12".to_string()),
             Token::Int("10".to_string()),
             Token::Eq,
             Token::Int("10".to_string()),

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -18,6 +18,7 @@ pub type BuiltinFunction = fn(Vec<Object>) -> EvalResult;
 pub enum Object {
     Boolean(bool),
     Integer(i64),
+    Float(f64),
     String(String),
     Array(Vec<Object>),
     Hash(HashMap<HashKey, Object>),
@@ -34,6 +35,7 @@ impl fmt::Display for Object {
         match self {
             Object::Boolean(value) => write!(f, "{}", value),
             Object::Integer(value) => write!(f, "{}", value),
+            Object::Float(value) => write!(f, "{}", value),
             Object::String(value) => write!(f, "\"{}\"", value),
             Object::Array(values) => {
                 let value_list = values
@@ -82,6 +84,7 @@ impl Object {
     pub fn from_constant(constant: &Constant) -> Object {
         match constant {
             Constant::Integer(value) => Object::Integer(*value),
+            Constant::Float(value) => Object::Float(*value),
             Constant::String(value) => Object::String(value.clone()),
             // TODO: Can I avoid cloning constants?
             Constant::CompiledFunction(value) => Object::CompiledFunction(value.clone()),
@@ -92,6 +95,7 @@ impl Object {
         match self {
             Object::Boolean(_) => "BOOLEAN",
             Object::Integer(_) => "INTEGER",
+            Object::Float(_) => "FLOAT",
             Object::String(_) => "STRING",
             Object::Array(_) => "ARRAY",
             Object::Hash(_) => "HASH",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -545,7 +545,7 @@ mod tests {
     fn let_statement() {
         let input = "
             let x = 5;
-            let y = 10;
+            let y = 10.23;
             let foobar = x + y;
         ";
         let lexer = Lexer::new(input.to_owned());
@@ -558,7 +558,7 @@ mod tests {
             program.statements,
             vec![
                 Statement::Let("x".to_string(), Expression::IntegerLiteral(5)),
-                Statement::Let("y".to_string(), Expression::IntegerLiteral(10)),
+                Statement::Let("y".to_string(), Expression::FloatLiteral(10.23)),
                 Statement::Let(
                     "foobar".to_string(),
                     Expression::Infix(
@@ -576,7 +576,7 @@ mod tests {
         let input = "
             return;
             return 5;
-            return 10;
+            return 8.0;
             return 993322;
         ";
 
@@ -591,7 +591,7 @@ mod tests {
             vec![
                 Statement::Return(None),
                 Statement::Return(Some(Expression::IntegerLiteral(5))),
-                Statement::Return(Some(Expression::IntegerLiteral(10))),
+                Statement::Return(Some(Expression::FloatLiteral(8.0))),
                 Statement::Return(Some(Expression::IntegerLiteral(993322))),
             ]
         );
@@ -636,6 +636,7 @@ mod tests {
         let tests = vec![
             ("!5;", Prefix::Bang, Expression::IntegerLiteral(5)),
             ("-15;", Prefix::Minus, Expression::IntegerLiteral(15)),
+            ("-0.25;", Prefix::Minus, Expression::FloatLiteral(0.25)),
             ("!true;", Prefix::Bang, Expression::Boolean(true)),
             ("!false;", Prefix::Bang, Expression::Boolean(false)),
         ];

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::ast::{BlockStatement, Expression, HashLiteral, Infix, Prefix, Program, Statement};
+use crate::ast::{BlockStatement, Expression, Infix, Prefix, Program, Statement};
 use crate::lexer::Lexer;
 use crate::token::Token;
-use std::collections::HashMap;
 use std::mem;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -25,6 +24,7 @@ pub enum ParserError {
     ExpectedIdentifierToken(Token),
     ExpectedBooleanToken(Token),
     ExpectedIntegerToken(Token),
+    ExpectedFloatToken(Token),
     ExpectedStringToken(Token),
     ExpectedLparen(Token),
     ExpectedRparen(Token),
@@ -36,6 +36,7 @@ pub enum ParserError {
     ExpectedComma(Token),
     ExpectedColon(Token),
     ParseInt(String),
+    ParseFloat(String),
 }
 
 type PrefixParseFn = fn(&mut Parser) -> Result<Expression>;
@@ -198,6 +199,7 @@ impl Parser {
         match &self.cur_token {
             Token::Ident(_) => Some(Parser::parse_identifier),
             Token::Int(_) => Some(Parser::parse_integer_literal),
+            Token::Float(_) => Some(Parser::parse_float_literal),
             Token::String(_) => Some(Parser::parse_string_literal),
             Token::True => Some(Parser::parse_boolean),
             Token::False => Some(Parser::parse_boolean),
@@ -232,6 +234,17 @@ impl Parser {
             }
         } else {
             Err(ParserError::ExpectedIntegerToken(self.cur_token.clone()))
+        }
+    }
+
+    fn parse_float_literal(&mut self) -> Result<Expression> {
+        if let Token::Float(float) = &self.cur_token {
+            match float.parse() {
+                Ok(value) => Ok(Expression::FloatLiteral(value)),
+                Err(_) => Err(ParserError::ParseFloat(float.to_string())),
+            }
+        } else {
+            Err(ParserError::ExpectedFloatToken(self.cur_token.clone()))
         }
     }
 
@@ -278,7 +291,7 @@ impl Parser {
 
     fn parse_hash_literal(&mut self) -> Result<Expression> {
         // cur_token: {
-        let mut pairs = HashMap::new();
+        let mut pairs = vec![];
 
         while self.peek_token != Token::Rbrace {
             // cur_token: { or ,
@@ -295,7 +308,7 @@ impl Parser {
             let value = self.parse_expression(Precedence::Lowest)?;
             // cur_token: the last token of the value expression
 
-            pairs.insert(key, value);
+            pairs.push((key, value));
 
             if self.peek_token != Token::Rbrace {
                 self.expect_peek(Token::Comma, ParserError::ExpectedComma)?;
@@ -306,7 +319,7 @@ impl Parser {
         self.expect_peek(Token::Rbrace, ParserError::ExpectedRbrace)?;
         // cur_token: }
 
-        Ok(Expression::Hash(HashLiteral { pairs }))
+        Ok(Expression::Hash(pairs))
     }
 
     fn parse_if_expression(&mut self) -> Result<Expression> {
@@ -771,7 +784,12 @@ mod tests {
             ("{true: 3}", "{true: 3};"),
             (
                 r#"{"one": 1, "two": 2, "three": 3}"#,
-                r#"{"one": 1, "three": 3, "two": 2};"#,
+                r#"{"one": 1, "two": 2, "three": 3};"#,
+            ),
+            // Duplicated entries
+            (
+                r#"{"one": 1, "one": 1, "two": 2}"#,
+                r#"{"one": 1, "one": 1, "two": 2};"#,
             ),
         ]);
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -8,6 +8,7 @@ pub enum Token {
     // Identifiers + literals
     Ident(String),  // add, foobar, x, y, ...
     Int(String),    // 123456
+    Float(String),  // 123.456
     String(String), // "hello"
 
     // Operators
@@ -52,6 +53,7 @@ impl fmt::Display for Token {
 
             Token::Ident(ident) => write!(f, "{}", ident),
             Token::Int(int) => write!(f, "{}", int),
+            Token::Float(float) => write!(f, "{}", float),
             // TODO: Escape `"` in a string as `\"`...
             Token::String(s) => write!(f, "\"{}\"", s),
 


### PR DESCRIPTION
Fixes #6

- [x] Lexer (supporting `12.34` but not `.5` or `2.`)
- [x] Parser
- [x] Eval
- [x] Compiler
- [x] VM

Other changes:

- [x] Have hash literal entries as a list instead of a hash map. Hash map should be created when the entries are evaluated.